### PR TITLE
Add sections for html and latex output to correct missing symbols in pdf

### DIFF
--- a/appendices/keyboard_shortcuts.rst
+++ b/appendices/keyboard_shortcuts.rst
@@ -19,101 +19,216 @@ Main window
 File
 ++++++
 
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+.. only:: html
 
-   "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
-   "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
-   "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
-   "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
+      "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
+      "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
+      "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add folder", "Ctrl+E", "⌘+E"
+      "Add files", "Ctrl+O", "⌘+O"
+      "Save selected files", "Ctrl+S", "⌘+S"
+      "Quit Picard", "Ctrl+Q", "⌘+Q"
 
 Edit
 ++++++
 
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+.. only:: html
 
-   "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
-   "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
-   "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
+      "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+      "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Cut selected files", "Ctrl+X", "⌘+X"
+      "Paste selected files", "Ctrl+V", "⌘+V"
+      "Show info for selected item", "Ctrl+I", "⌘+I"
 
 View
 ++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
-   "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
+      "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Toggle file browser", "Ctrl+B", "⌘+B"
+      "Toggle metadata view", "Ctrl+Shift+M", "⌘+⇧+M"
 
 Tools
 +++++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
-   "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
-   "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
-   "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
-   "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
-   "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
-   "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
-   "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
-   "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
+      "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
+      "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
+      "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
+      "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
+      "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
+      "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
+      "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
+      "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Refresh", "Ctrl+R", "⌘+R"
+      "Lookup CD", "Ctrl+K", "⌘+K"
+      "Lookup", "Ctrl+L", "⌘+L"
+      "Scan", "Ctrl+Y", "⌘+Y"
+      "Cluster", "Ctrl+U", "⌘+U"
+      "Lookup in browser", "Ctrl+Shift+L", "⌘+⇧+L"
+      "Search for similar tracks", "Ctrl+T", "⌘+T"
+      "Generate AcoustID fingerprints", "Ctrl+Shift+Y", "⌘+⇧+Y"
+      "Tags from file names", "Ctrl+Shift+T", "⌘+⇧+T"
 
 Help
 +++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Help", :kbd:`F1`, :kbd:`⌘+?`
-   "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
-   "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Help", :kbd:`F1`, :kbd:`⌘+?`
+      "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
+      "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Help", "F1", "⌘+?"
+      "View activity history", "Ctrl+H", "⌘+⇧+H"
+      "View error/debug log", "Ctrl+G", "⌘+G"
 
 Metadata view
 +++++++++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
-   "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
-   "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
-   "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
-   "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
+      "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
+      "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+      "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
+      "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add new tag", "Alt+Shift+A", "⌥+⇧+A"
+      "Edit selected tag", "Alt+Shift+E", "⌥+⇧+E"
+      "Remove selected tag", "Alt+Shift+R |br| |nl| Del", "⌥+⇧+R |br| |nl| Del |br| |nl| ⌘+⌫"
+      "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
+      "Paste to selected tag value", "Ctrl+V", "⌘+V"
 
 Other
 ++++++++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
-   "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+.. only:: html
 
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
+      "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Focus search", "Ctrl+F", "⌘+F"
+      "Remove selected item", Del, "Del |br| |nl| ⌘+⌫"
 
 Script editor
 -------------
 
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+.. only:: html
 
-   "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
-   "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
-   "Hide completions", :kbd:`Esc`, :kbd:`Esc`
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
+      "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
+      "Hide completions", :kbd:`Esc`, :kbd:`Esc`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Show auto completion", "Ctrl+Space", "⌃+Space"
+      "Use selected completion", "Tab |br| |nl| Return", "Tab |br| |nl| Return"
+      "Hide completions", "Esc", "Esc"
 
 .. raw:: latex
 


### PR DESCRIPTION
Special characters were not being displayed in the PDF output.  I suspect that the `:kbd:` directive is using a different font that doesn't have the special characters mapped in the latex output.  As a temporary work-around, separate tables are being created for the html and latex outputs.